### PR TITLE
Hide ov::Model from wrappers

### DIFF
--- a/src/cpp/include/adapters/inference_adapter.h
+++ b/src/cpp/include/adapters/inference_adapter.h
@@ -36,6 +36,11 @@ public:
                            const std::string& device = "",
                            const ov::AnyMap& compilationConfig = {},
                            size_t max_num_requests = 0) = 0;
+    virtual void loadModelFile(const std::string& modelPath,
+                               const std::string& device = "",
+                               const ov::AnyMap& adapterConfig = {},
+                               bool preCompile = true) = 0;
+    virtual void compileModel(const std::string& device = "", const ov::AnyMap& adapterConfig = {}) = 0;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const = 0;
     virtual ov::PartialShape getOutputShape(const std::string& inputName) const = 0;
     virtual ov::element::Type_t getInputDatatype(const std::string& inputName) const = 0;

--- a/src/cpp/include/adapters/inference_adapter.h
+++ b/src/cpp/include/adapters/inference_adapter.h
@@ -31,15 +31,10 @@ public:
     virtual void awaitAll() = 0;
     virtual void awaitAny() = 0;
     virtual size_t getNumAsyncExecutors() const = 0;
-    virtual void loadModel(const std::shared_ptr<const ov::Model>& model,
-                           ov::Core& core,
+    virtual void loadModel(const std::string& modelPath,
                            const std::string& device = "",
-                           const ov::AnyMap& compilationConfig = {},
-                           size_t max_num_requests = 0) = 0;
-    virtual void loadModelFile(const std::string& modelPath,
-                               const std::string& device = "",
-                               const ov::AnyMap& adapterConfig = {},
-                               bool preCompile = true) = 0;
+                           const ov::AnyMap& adapterConfig = {},
+                           bool preCompile = true) = 0;
     virtual void compileModel(const std::string& device = "", const ov::AnyMap& adapterConfig = {}) = 0;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const = 0;
     virtual ov::PartialShape getOutputShape(const std::string& inputName) const = 0;

--- a/src/cpp/include/adapters/openvino_adapter.h
+++ b/src/cpp/include/adapters/openvino_adapter.h
@@ -25,15 +25,10 @@ public:
     virtual bool isReady();
     virtual void awaitAll();
     virtual void awaitAny();
-    virtual void loadModel(const std::shared_ptr<const ov::Model>& model,
-                           ov::Core& core,
+    virtual void loadModel(const std::string& modelPath,
                            const std::string& device = "",
-                           const ov::AnyMap& compilationConfig = {},
-                           size_t max_num_requests = 1) override;
-    virtual void loadModelFile(const std::string& modelPath,
-                               const std::string& device = "",
-                               const ov::AnyMap& adapterConfig = {},
-                               bool preCompile = true) override;
+                           const ov::AnyMap& adapterConfig = {},
+                           bool preCompile = true) override;
     virtual void compileModel(const std::string& device = "", const ov::AnyMap& adapterConfig = {}) override;
     virtual size_t getNumAsyncExecutors() const;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const override;
@@ -44,7 +39,7 @@ public:
     virtual std::vector<std::string> getOutputNames() const override;
     virtual const ov::AnyMap& getModelConfig() const override;
 
-    void applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> func);
+    void applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> t);
 
 protected:
     void initInputsOutputs();

--- a/src/cpp/include/adapters/openvino_adapter.h
+++ b/src/cpp/include/adapters/openvino_adapter.h
@@ -30,6 +30,11 @@ public:
                            const std::string& device = "",
                            const ov::AnyMap& compilationConfig = {},
                            size_t max_num_requests = 1) override;
+    virtual void loadModelFile(const std::string& modelPath,
+                               const std::string& device = "",
+                               const ov::AnyMap& adapterConfig = {},
+                               bool preCompile = true) override;
+    virtual void compileModel(const std::string& device = "", const ov::AnyMap& adapterConfig = {}) override;
     virtual size_t getNumAsyncExecutors() const;
     virtual ov::PartialShape getInputShape(const std::string& inputName) const override;
     virtual ov::PartialShape getOutputShape(const std::string& outputName) const override;
@@ -38,6 +43,8 @@ public:
     virtual std::vector<std::string> getInputNames() const override;
     virtual std::vector<std::string> getOutputNames() const override;
     virtual const ov::AnyMap& getModelConfig() const override;
+
+    void applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> func);
 
 protected:
     void initInputsOutputs();
@@ -48,7 +55,6 @@ protected:
     std::vector<std::string> outputNames;
     std::unique_ptr<AsyncInferQueue> asyncQueue;
     ov::AnyMap modelConfig;  // the content of model_info section of rt_info
-
-public:
+    std::shared_ptr<ov::Model> model;
     ov::CompiledModel compiledModel;
 };

--- a/src/cpp/src/adapters/openvino_adapter.cpp
+++ b/src/cpp/src/adapters/openvino_adapter.cpp
@@ -9,6 +9,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "utils/config.h"
+
 void OpenVINOInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& model,
                                          ov::Core& core,
                                          const std::string& device,
@@ -37,6 +39,56 @@ void OpenVINOInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>&
     if (model->has_rt_info({"model_info"})) {
         modelConfig = model->get_rt_info<ov::AnyMap>("model_info");
     }
+}
+
+void OpenVINOInferenceAdapter::compileModel(const std::string& device, const ov::AnyMap& adapterConfig) {
+    if (!model) {
+        throw std::runtime_error("Model is not loaded");
+    }
+    size_t max_num_requests = 1;
+    max_num_requests = utils::get_from_any_maps("max_num_requests", adapterConfig, {}, max_num_requests);
+
+    ov::AnyMap customCompilationConfig(adapterConfig);
+    if (max_num_requests != 1) {
+        if (customCompilationConfig.find("PERFORMANCE_HINT") == customCompilationConfig.end()) {
+            customCompilationConfig["PERFORMANCE_HINT"] = ov::hint::PerformanceMode::THROUGHPUT;
+        }
+        if (max_num_requests > 0) {
+            if (customCompilationConfig.find("PERFORMANCE_HINT_NUM_REQUESTS") == customCompilationConfig.end()) {
+                customCompilationConfig["PERFORMANCE_HINT_NUM_REQUESTS"] = ov::hint::num_requests(max_num_requests);
+            }
+        }
+    } else {
+        if (customCompilationConfig.find("PERFORMANCE_HINT") == customCompilationConfig.end()) {
+            customCompilationConfig["PERFORMANCE_HINT"] = ov::hint::PerformanceMode::LATENCY;
+        }
+    }
+
+    ov::Core core;
+    compiledModel = core.compile_model(model, device, customCompilationConfig);
+    asyncQueue = std::make_unique<AsyncInferQueue>(compiledModel, max_num_requests);
+    initInputsOutputs();
+}
+
+void OpenVINOInferenceAdapter::loadModelFile(const std::string& modelPath,
+                                             const std::string& device,
+                                             const ov::AnyMap& adapterConfig,
+                                             bool preCompile) {
+    ov::Core core;
+    model = core.read_model(modelPath);
+    if (model->has_rt_info({"model_info"})) {
+        modelConfig = model->get_rt_info<ov::AnyMap>("model_info");
+    }
+    if (preCompile) {
+        compileModel(device, adapterConfig);
+    }
+}
+
+void OpenVINOInferenceAdapter::applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> func) {
+    if (!model) {
+        throw std::runtime_error("Model is not loaded");
+    }
+    func(model);
 }
 
 void OpenVINOInferenceAdapter::infer(const InferenceInput& input, InferenceOutput& output) {

--- a/src/cpp/src/adapters/openvino_adapter.cpp
+++ b/src/cpp/src/adapters/openvino_adapter.cpp
@@ -11,36 +11,6 @@
 
 #include "utils/config.h"
 
-void OpenVINOInferenceAdapter::loadModel(const std::shared_ptr<const ov::Model>& model,
-                                         ov::Core& core,
-                                         const std::string& device,
-                                         const ov::AnyMap& compilationConfig,
-                                         size_t max_num_requests) {
-    ov::AnyMap customCompilationConfig(compilationConfig);
-    if (max_num_requests != 1) {
-        if (customCompilationConfig.find("PERFORMANCE_HINT") == customCompilationConfig.end()) {
-            customCompilationConfig["PERFORMANCE_HINT"] = ov::hint::PerformanceMode::THROUGHPUT;
-        }
-        if (max_num_requests > 0) {
-            if (customCompilationConfig.find("PERFORMANCE_HINT_NUM_REQUESTS") == customCompilationConfig.end()) {
-                customCompilationConfig["PERFORMANCE_HINT_NUM_REQUESTS"] = ov::hint::num_requests(max_num_requests);
-            }
-        }
-    } else {
-        if (customCompilationConfig.find("PERFORMANCE_HINT") == customCompilationConfig.end()) {
-            customCompilationConfig["PERFORMANCE_HINT"] = ov::hint::PerformanceMode::LATENCY;
-        }
-    }
-
-    compiledModel = core.compile_model(model, device, customCompilationConfig);
-    asyncQueue = std::make_unique<AsyncInferQueue>(compiledModel, max_num_requests);
-    initInputsOutputs();
-
-    if (model->has_rt_info({"model_info"})) {
-        modelConfig = model->get_rt_info<ov::AnyMap>("model_info");
-    }
-}
-
 void OpenVINOInferenceAdapter::compileModel(const std::string& device, const ov::AnyMap& adapterConfig) {
     if (!model) {
         throw std::runtime_error("Model is not loaded");
@@ -70,10 +40,10 @@ void OpenVINOInferenceAdapter::compileModel(const std::string& device, const ov:
     initInputsOutputs();
 }
 
-void OpenVINOInferenceAdapter::loadModelFile(const std::string& modelPath,
-                                             const std::string& device,
-                                             const ov::AnyMap& adapterConfig,
-                                             bool preCompile) {
+void OpenVINOInferenceAdapter::loadModel(const std::string& modelPath,
+                                         const std::string& device,
+                                         const ov::AnyMap& adapterConfig,
+                                         bool preCompile) {
     ov::Core core;
     model = core.read_model(modelPath);
     if (model->has_rt_info({"model_info"})) {
@@ -84,11 +54,14 @@ void OpenVINOInferenceAdapter::loadModelFile(const std::string& modelPath,
     }
 }
 
-void OpenVINOInferenceAdapter::applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> func) {
+void OpenVINOInferenceAdapter::applyModelTransform(std::function<void(std::shared_ptr<ov::Model>&)> t) {
     if (!model) {
         throw std::runtime_error("Model is not loaded");
     }
-    func(model);
+    t(model);
+    if (model->has_rt_info({"model_info"})) {
+        modelConfig = model->get_rt_info<ov::AnyMap>("model_info");
+    }
 }
 
 void OpenVINOInferenceAdapter::infer(const InferenceInput& input, InferenceOutput& output) {

--- a/src/cpp/src/tasks/anomaly.cpp
+++ b/src/cpp/src/tasks/anomaly.cpp
@@ -5,6 +5,11 @@
 #include "utils/tensor.h"
 
 void Anomaly::serialize(std::shared_ptr<ov::Model>& ov_model) {
+    if (utils::model_has_embedded_processing(ov_model)) {
+        std::cout << "model already was serialized" << std::endl;
+        return;
+    }
+
     auto input = ov_model->inputs().front();
 
     auto layout = ov::layout::get_layout(input);
@@ -47,23 +52,21 @@ void Anomaly::serialize(std::shared_ptr<ov::Model>& ov_model) {
 }
 
 Anomaly Anomaly::load(const std::string& model_path) {
-    auto core = ov::Core();
-    std::shared_ptr<ov::Model> model = core.read_model(model_path);
+    auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
+    adapter->loadModelFile(model_path, "", {}, false);
 
-    if (model->has_rt_info("model_info", "model_type")) {
-        std::cout << "has model type in info: " << model->get_rt_info<std::string>("model_info", "model_type")
-                  << std::endl;
+    std::string model_type;
+    model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);
+
+    if (!model_type.empty()) {
+        std::cout << "has model type in info: " << model_type << std::endl;
     } else {
         throw std::runtime_error("Incorrect or unsupported model_type");
     }
 
-    if (utils::model_has_embedded_processing(model)) {
-        std::cout << "model already was serialized" << std::endl;
-    } else {
-        serialize(model);
-    }
-    auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModel(model, core, "AUTO");
+    adapter->applyModelTransform(Anomaly::serialize);
+    adapter->compileModel("AUTO", {});
+
     return Anomaly(adapter);
 }
 

--- a/src/cpp/src/tasks/anomaly.cpp
+++ b/src/cpp/src/tasks/anomaly.cpp
@@ -53,7 +53,7 @@ void Anomaly::serialize(std::shared_ptr<ov::Model>& ov_model) {
 
 Anomaly Anomaly::load(const std::string& model_path) {
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModelFile(model_path, "", {}, false);
+    adapter->loadModel(model_path, "", {}, false);
 
     std::string model_type;
     model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);

--- a/src/cpp/src/tasks/classification.cpp
+++ b/src/cpp/src/tasks/classification.cpp
@@ -182,7 +182,7 @@ void Classification::serialize(std::shared_ptr<ov::Model>& ov_model) {
 
 Classification Classification::load(const std::string& model_path) {
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModelFile(model_path, "", {}, false);
+    adapter->loadModel(model_path, "", {}, false);
 
     std::string model_type;
     model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);

--- a/src/cpp/src/tasks/classification.cpp
+++ b/src/cpp/src/tasks/classification.cpp
@@ -83,6 +83,10 @@ std::vector<size_t> get_non_xai_output_indices(const std::vector<ov::Output<ov::
 }  // namespace
 
 void Classification::serialize(std::shared_ptr<ov::Model>& ov_model) {
+    if (utils::model_has_embedded_processing(ov_model)) {
+        std::cout << "model already was serialized" << std::endl;
+        return;
+    }
     // --------------------------- Configure input & output -------------------------------------------------
     // --------------------------- Prepare input  ------------------------------------------------------
     auto config = ov_model->has_rt_info("model_info") ? ov_model->get_rt_info<ov::AnyMap>("model_info") : ov::AnyMap{};
@@ -177,23 +181,18 @@ void Classification::serialize(std::shared_ptr<ov::Model>& ov_model) {
 }
 
 Classification Classification::load(const std::string& model_path) {
-    auto core = ov::Core();
-    std::shared_ptr<ov::Model> model = core.read_model(model_path);
-
-    if (model->has_rt_info("model_info", "model_type")) {
-        std::cout << "has model type in info: " << model->get_rt_info<std::string>("model_info", "model_type")
-                  << std::endl;
-    } else {
-        throw std::runtime_error("Incorrect or unsupported model_type");
-    }
-
-    if (utils::model_has_embedded_processing(model)) {
-        std::cout << "model already was serialized" << std::endl;
-    } else {
-        Classification::serialize(model);
-    }
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModel(model, core, "AUTO");
+    adapter->loadModelFile(model_path, "", {}, false);
+
+    std::string model_type;
+    model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);
+
+    if (model_type.empty() || model_type != "Classification") {
+        throw std::runtime_error("Incorrect or unsupported model_type, expected: Classification");
+    }
+    adapter->applyModelTransform(Classification::serialize);
+    adapter->compileModel("AUTO", {});
+
     return Classification(adapter);
 }
 

--- a/src/cpp/src/tasks/detection.cpp
+++ b/src/cpp/src/tasks/detection.cpp
@@ -12,23 +12,19 @@
 #include "utils/tensor.h"
 
 DetectionModel DetectionModel::load(const std::string& model_path, const ov::AnyMap& configuration) {
-    auto core = ov::Core();
-    std::shared_ptr<ov::Model> model = core.read_model(model_path);
-
-    if (model->has_rt_info("model_info", "model_type")) {
-        std::cout << "has model type in info: " << model->get_rt_info<std::string>("model_info", "model_type")
-                  << std::endl;
-    } else {
-        throw std::runtime_error("Incorrect or unsupported model_type");
-    }
-
-    if (utils::model_has_embedded_processing(model)) {
-        std::cout << "model already was serialized" << std::endl;
-    } else {
-        SSD::serialize(model);
-    }
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModel(model, core, "AUTO");
+    adapter->loadModelFile(model_path, "", {}, false);
+
+    std::string model_type;
+    model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);
+    transform(model_type.begin(), model_type.end(), model_type.begin(), ::tolower);
+
+    if (model_type.empty() || model_type != "ssd") {
+        throw std::runtime_error("Incorrect or unsupported model_type, expected: ssd");
+    }
+    adapter->applyModelTransform(SSD::serialize);
+    adapter->compileModel("AUTO", {});
+
     return DetectionModel(std::make_unique<SSD>(adapter), configuration);
 }
 

--- a/src/cpp/src/tasks/detection.cpp
+++ b/src/cpp/src/tasks/detection.cpp
@@ -13,7 +13,7 @@
 
 DetectionModel DetectionModel::load(const std::string& model_path, const ov::AnyMap& configuration) {
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModelFile(model_path, "", {}, false);
+    adapter->loadModel(model_path, "", {}, false);
 
     std::string model_type;
     model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);

--- a/src/cpp/src/tasks/detection/ssd.cpp
+++ b/src/cpp/src/tasks/detection/ssd.cpp
@@ -68,6 +68,10 @@ std::map<std::string, ov::Tensor> SSD::preprocess(cv::Mat image) {
 }
 
 void SSD::serialize(std::shared_ptr<ov::Model> ov_model) {
+    if (utils::model_has_embedded_processing(ov_model)) {
+        std::cout << "model already was serialized" << std::endl;
+        return;
+    }
     auto output_mode = ov_model->outputs().size() > 1 ? SSDOutputMode::multi : SSDOutputMode::single;
 
     auto input_tensor = ov_model->inputs()[0];

--- a/src/cpp/src/tasks/instance_segmentation.cpp
+++ b/src/cpp/src/tasks/instance_segmentation.cpp
@@ -192,7 +192,7 @@ void InstanceSegmentation::serialize(std::shared_ptr<ov::Model>& ov_model) {
 
 InstanceSegmentation InstanceSegmentation::load(const std::string& model_path) {
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModelFile(model_path, "", {}, false);
+    adapter->loadModel(model_path, "", {}, false);
 
     std::string model_type;
     model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);

--- a/src/cpp/src/tasks/instance_segmentation.cpp
+++ b/src/cpp/src/tasks/instance_segmentation.cpp
@@ -122,6 +122,10 @@ cv::Mat segm_postprocess(const SegmentedObject& box, const cv::Mat& unpadded, in
 }
 
 void InstanceSegmentation::serialize(std::shared_ptr<ov::Model>& ov_model) {
+    if (utils::model_has_embedded_processing(ov_model)) {
+        std::cout << "model already was serialized" << std::endl;
+        return;
+    }
     if (ov_model->inputs().size() != 1) {
         throw std::logic_error("MaskRCNNModel model wrapper supports topologies with only 1 input");
     }
@@ -187,23 +191,18 @@ void InstanceSegmentation::serialize(std::shared_ptr<ov::Model>& ov_model) {
 }
 
 InstanceSegmentation InstanceSegmentation::load(const std::string& model_path) {
-    auto core = ov::Core();
-    std::shared_ptr<ov::Model> model = core.read_model(model_path);
-
-    if (model->has_rt_info("model_info", "model_type")) {
-        std::cout << "has model type in info: " << model->get_rt_info<std::string>("model_info", "model_type")
-                  << std::endl;
-    } else {
-        throw std::runtime_error("Incorrect or unsupported model_type");
-    }
-
-    if (utils::model_has_embedded_processing(model)) {
-        std::cout << "model already was serialized" << std::endl;
-    } else {
-        serialize(model);
-    }
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModel(model, core, "AUTO");
+    adapter->loadModelFile(model_path, "", {}, false);
+
+    std::string model_type;
+    model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);
+
+    if (model_type.empty() || model_type != "MaskRCNN") {
+        throw std::runtime_error("Incorrect or unsupported model_type, expected: MaskRCNN");
+    }
+    adapter->applyModelTransform(InstanceSegmentation::serialize);
+    adapter->compileModel("AUTO", {});
+
     return InstanceSegmentation(adapter);
 }
 

--- a/src/cpp/src/tasks/semantic_segmentation.cpp
+++ b/src/cpp/src/tasks/semantic_segmentation.cpp
@@ -22,7 +22,7 @@ cv::Mat get_activation_map(const cv::Mat& features) {
 
 SemanticSegmentation SemanticSegmentation::load(const std::string& model_path) {
     auto adapter = std::make_shared<OpenVINOInferenceAdapter>();
-    adapter->loadModelFile(model_path, "", {}, false);
+    adapter->loadModel(model_path, "", {}, false);
 
     std::string model_type;
     model_type = utils::get_from_any_maps("model_type", adapter->getModelConfig(), {}, model_type);


### PR DESCRIPTION
# What does this PR do?

To support ONNX models with OV adapter, we need to hide actual OV model from the wrapper and handle it in the adapter only.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
