### PR TITLE
chore(ci): configure dependabot to use semanctic commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: pip
     directory: /src
     schedule:
@@ -17,3 +19,5 @@ updates:
     target-branch: "master"
     ignore:
       - dependency-name: "ultralytics"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
# What does this PR do?

Dependabot was configured to create pr titiles starting with `chore(deps)` as proposed by Conventional Commits

Fixes #367 367

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
