### PR TITLE
chore(comments): remove comment in annotations import

### DIFF
--- a/src/model_api/adapters/inference_adapter.py
+++ b/src/model_api/adapters/inference_adapter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field

--- a/src/model_api/adapters/onnx_adapter.py
+++ b/src/model_api/adapters/onnx_adapter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import sys
 from functools import partial, reduce

--- a/src/model_api/adapters/openvino_adapter.py
+++ b/src/model_api/adapters/openvino_adapter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import logging as log
 from pathlib import Path

--- a/src/model_api/adapters/ovms_adapter.py
+++ b/src/model_api/adapters/ovms_adapter.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import re
 from typing import Any, Callable

--- a/src/model_api/adapters/utils.py
+++ b/src/model_api/adapters/utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import math
 from functools import partial

--- a/src/model_api/models/classification.py
+++ b/src/model_api/models/classification.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import copy
 import json

--- a/src/model_api/models/image_model.py
+++ b/src/model_api/models/image_model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 

--- a/src/model_api/models/model.py
+++ b/src/model_api/models/model.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 import logging as log
 import re

--- a/src/model_api/models/sam_models.py
+++ b/src/model_api/models/sam_models.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any

--- a/src/model_api/models/segmentation.py
+++ b/src/model_api/models/segmentation.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 

--- a/src/model_api/models/types.py
+++ b/src/model_api/models/types.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from typing import Any
 

--- a/src/model_api/models/utils.py
+++ b/src/model_api/models/utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/model_api/models/visual_prompting.py
+++ b/src/model_api/models/visual_prompting.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from collections import defaultdict
 from itertools import product

--- a/src/model_api/visualizer/visualizer.py
+++ b/src/model_api/visualizer/visualizer.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations  # TODO: remove when Python3.9 support is dropped
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
# What does this PR do?

Our code includes `from __future__ import annotations` statements, some of those were marked as to be removed when moved to Python 3.10 - it was believed at that time that such imports will not be needed anymore.

`annotations` are still needed - as mentined in https://docs.python.org/3/library/__future__.html#id2 inclusion of that behavior was  not included in Python 3.10 or 3.11, and finally posponed indefinitely.

In effect comments advising removal of imports were removed.

Fixes #363

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
