### PR TITLE
test: models from geti_predict used in tests

### DIFF
--- a/tests/accuracy/prepare_data.py
+++ b/tests/accuracy/prepare_data.py
@@ -88,6 +88,7 @@ async def main():
             ),
             download_otx_model(client, otx_models_dir, "cls_efficient_b0_cars"),
             download_otx_model(client, otx_models_dir, "cls_efficient_v2s_cars"),
+            download_otx_model(client, otx_models_dir, "tinynet_imagenet"),
             download_otx_model(client, otx_models_dir, "Lite-hrnet-18"),
             download_otx_model(client, otx_models_dir, "Lite-hrnet-18_mod2"),
             download_otx_model(client, otx_models_dir, "Lite-hrnet-s_mod2"),

--- a/tests/accuracy/prepare_data.py
+++ b/tests/accuracy/prepare_data.py
@@ -35,19 +35,19 @@ async def download_otx_model(client, otx_models_dir, model_name, format="xml"):
     if format == "onnx":
         await stream_file(
             client,
-            f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/model.onnx",
+            f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/model.onnx",
             f"{otx_models_dir}/{model_name}.onnx",
         )
     else:
         await asyncio.gather(
             stream_file(
                 client,
-                f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/openvino.xml",
+                f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/openvino.xml",
                 f"{otx_models_dir}/{model_name}.xml",
             ),
             stream_file(
                 client,
-                f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/openvino.bin",
+                f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/openvino.bin",
                 f"{otx_models_dir}/{model_name}.bin",
             ),
         )

--- a/tests/accuracy/public_scope.json
+++ b/tests/accuracy/public_scope.json
@@ -208,6 +208,16 @@
     ]
   },
   {
+    "name": "otx_models/tinynet_imagenet.xml",
+    "type": "ClassificationModel",
+    "test_data": [
+      {
+        "image": "coco128/images/train2017/000000000471.jpg",
+        "reference": ["42 (42): 1.000, [0], [0], [0]"]
+      }
+    ]
+  },
+  {
     "name": "otx_models/is_efficientnetb2b_maskrcnn_coco_reduced.xml",
     "type": "MaskRCNNModel",
     "test_data": [

--- a/tests/precommit/prepare_data.py
+++ b/tests/precommit/prepare_data.py
@@ -14,16 +14,16 @@ def retrieve_otx_model(data_dir, model_name, format="xml"):
     destination_folder.mkdir(parents=True, exist_ok=True)
     if format == "onnx":
         urlretrieve(
-            f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/model.onnx",
+            f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/model.onnx",
             destination_folder / f"{model_name}.onnx",
         )
     else:
         urlretrieve(
-            f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/openvino.xml",
+            f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/openvino.xml",
             destination_folder / f"{model_name}.xml",
         )
         urlretrieve(
-            f"https://storage.openvinotoolkit.org/repositories/model_api/test/otx_models/{model_name}/openvino.bin",
+            f"https://storage.geti.intel.com/geti_predict/test/otx_models/{model_name}/openvino.bin",
             f"{destination_folder}/{model_name}.bin",
         )
 


### PR DESCRIPTION
# What does this PR do?

Tests (pre-commit and accuracy) are using models downloaded from public repository.

This PR changes the location used from `storage.openvinotoolkit.org/repositories/model_api` to new one `storage.geti.intel.com/geti_predict` that will be used as a future storage place for Model API.


Fixes #385 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
