### PR TITLE
test: ability to select device used by OpenvinoAdapter

### DIFF
--- a/tests/accuracy/conftest.py
+++ b/tests/accuracy/conftest.py
@@ -11,6 +11,12 @@ import pytest
 def pytest_addoption(parser):
     parser.addoption("--data", action="store", help="data folder with dataset")
     parser.addoption(
+        "--device",
+        action="store",
+        default="CPU",
+        help="device to run tests on (in case of OpenvinoAdapter)",
+    )
+    parser.addoption(
         "--dump",
         action="store_true",
         default=False,


### PR DESCRIPTION
# What does this PR do?

OpenvinoAdapter allows to select the device inference will be executed on.
For Accuracy tests it was hardcoded to `"CPU"`, now it's configurable by `--device` argument (with default value of `"CPU"`).
This allows to run Accuracy tests on iGPU or NPU with a simple command line command.

Fixes #398 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
