### PR TITLE
tests: option to save test results as images

### DIFF
--- a/tests/accuracy/conftest.py
+++ b/tests/accuracy/conftest.py
@@ -28,6 +28,12 @@ def pytest_addoption(parser):
         default=False,
         help="whether to dump results into json file",
     )
+    parser.addoption(
+        "--results-dir",
+        action="store",
+        default="",
+        help="directory to store inference result",
+    )
 
 
 def pytest_configure(config):


### PR DESCRIPTION
# What does this PR do?

Adding `--results-dir` option to `test_accuracy.py` will save images with inference results in specified directory.

Fixes #409 
