### PR TITLE
feat(tests): run inference tests only on selected model type

### DIFF
--- a/model_api/tests/functional/conftest.py
+++ b/model_api/tests/functional/conftest.py
@@ -34,6 +34,12 @@ def pytest_addoption(parser):
         default="",
         help="directory to store inference result",
     )
+    parser.addoption(
+        "--only-model-type",
+        action="store",
+        default="",
+        help="select model type to run tests on (and all that inherit from it)",
+    )
 
 
 def pytest_configure(config):

--- a/model_api/tests/functional/test_inference.py
+++ b/model_api/tests/functional/test_inference.py
@@ -6,6 +6,7 @@ import ast
 import json
 import operator
 from pathlib import Path
+from typing import Type
 
 import cv2
 import numpy as np
@@ -32,6 +33,7 @@ from model_api.models import (
     InstanceSegmentationResult,
     KeypointDetectionModel,
     MaskRCNNModel,
+    Model,
     Prompt,
     SAMDecoder,
     SAMImageEncoder,
@@ -143,6 +145,14 @@ def result(pytestconfig):
 @pytest.fixture(scope="session")
 def model_data_file(pytestconfig):
     return pytestconfig.getoption("model_data")
+
+
+@pytest.fixture(scope="session")
+def only_model_class(pytestconfig):
+    model_type = pytestconfig.getoption("only_model_type")
+    if not model_type:
+        return None
+    return Model.get_model_class(model_type)
 
 
 def pytest_generate_tests(metafunc):
@@ -416,13 +426,18 @@ def assert_contours_match(actual: list[dict], expected: list[dict]) -> None:
         )
 
 
-def test_image_models(data, device, dump, result, model_data, results_dir):  # noqa: C901
+def test_image_models(data, device, dump, result, model_data, results_dir, only_model_class):  # noqa: C901
     name = model_data["name"]
+
+    model_type = MODEL_TYPE_MAPPING[model_data["type"]]
+    if only_model_class and not issubclass(model_type, only_model_class):
+        pytest.skip(f"Skipping {name} as it is not a subclass of {only_model_class.__name__}")
+
     if name.endswith((".xml", ".onnx")):
         name = f"{data}/{name}"
 
     for model in create_models(
-        MODEL_TYPE_MAPPING[model_data["type"]],
+        model_type,
         name,
         data,
         model_data.get("force_ort", False),

--- a/model_api/tests/functional/test_inference.py
+++ b/model_api/tests/functional/test_inference.py
@@ -148,7 +148,7 @@ def model_data_file(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def only_model_class(pytestconfig):
+def only_model_class(pytestconfig) -> Type[Model] | None:
     model_type = pytestconfig.getoption("only_model_type")
     if not model_type:
         return None


### PR DESCRIPTION
# What does this PR do?

This PR adds a pytest CLI filter to the functional inference tests so contributors can run the inference suite only for a selected wrapper/model type (and its subclasses), reducing runtime and focusing validation.

<!-- Remove if not applicable -->

Fixes #598

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
