### PR TITLE
chore: link main README in model_api

### DIFF
--- a/model_api/README.md
+++ b/model_api/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/model_api/pyproject.toml
+++ b/model_api/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
   {name = "Intel(R) Corporation"},
 ]
 description = "Model API: model wrappers and pipelines for inference with OpenVINO"
-readme = "../README.md"
+readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
# What does this PR do?

Link to README.md was created in `model_api` directory to satisfy requirement in hatchling.build >= 1.32